### PR TITLE
Redesign (brutalist): first pass

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,9 +1,14 @@
 import Container from "./container";
+import ThemePicker from "./theme-picker";
 
 const Footer = () => {
   return (
     <footer className="bg-neutral-50 border-t border-neutral-200">
-      <Container></Container>
+      <Container>
+        <div className="py-6 flex items-center justify-end">
+          <ThemePicker />
+        </div>
+      </Container>
     </footer>
   );
 };

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -3,9 +3,9 @@ import Link from "next/link";
 const Header = () => {
   return (
     <div className="px-4 md:px-8 lg:px-12 max-w-5xl mx-auto mt-6 mb-10">
-      <h1 className="inline-block brutal-border bg-white px-3 py-2 text-2xl md:text-4xl font-extrabold tracking-tight">
+      <h1 className="inline-block brutal-border bg-[color:var(--brutal-card)] px-3 py-2 text-2xl md:text-4xl font-extrabold tracking-tight text-[color:var(--brutal-fg)]">
         <Link href="/">
-          <a className="no-underline text-black">iancanderson</a>
+          <a className="no-underline text-[color:var(--brutal-fg)]">iancanderson</a>
         </Link>
       </h1>
     </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -2,11 +2,13 @@ import Link from "next/link";
 
 const Header = () => {
   return (
-    <h2 className="text-2xl md:text-4xl font-bold tracking-tight md:tracking-tighter leading-tight mb-20 mt-8">
-      <Link href="/">
-        <a className="hover:underline">iancanderson</a>
-      </Link>
-    </h2>
+    <div className="px-4 md:px-8 lg:px-12 max-w-5xl mx-auto mt-6 mb-10">
+      <h1 className="inline-block brutal-border bg-white px-3 py-2 text-2xl md:text-4xl font-extrabold tracking-tight">
+        <Link href="/">
+          <a className="no-underline text-black">iancanderson</a>
+        </Link>
+      </h1>
+    </div>
   );
 };
 

--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -15,7 +15,7 @@ const HeroPost = ({ title, date, externalUrl, slug, isVideo, tags }: Props) => {
   return (
     <section>
       <div className="mb-10">
-        <div className="brutal-border bg-[color:var(--brutal-card)] p-5">
+        <div className="brutal-border bg-[color:var(--brutal-card)] p-5 text-[color:var(--brutal-fg)]">
           <h3 className="mb-3 text-3xl lg:text-4xl leading-tight">
             {isVideo && (
               <span className="mr-3 align-middle inline-block text-xs font-semibold uppercase tracking-wide text-red-600">Video</span>
@@ -23,7 +23,7 @@ const HeroPost = ({ title, date, externalUrl, slug, isVideo, tags }: Props) => {
             <PostLink externalUrl={externalUrl} title={title} slug={slug} />
           </h3>
           {Array.isArray(tags) && tags.length > 0 && (
-            <div className="mb-2 text-sm text-gray-800">
+            <div className="mb-2 text-sm">
               {tags.map((t) => (
                 <Link key={t} href={`/tags/${t}`}>
                   <a className="brutal-tag">#{t}</a>

--- a/components/hero-post.tsx
+++ b/components/hero-post.tsx
@@ -14,24 +14,24 @@ type Props = {
 const HeroPost = ({ title, date, externalUrl, slug, isVideo, tags }: Props) => {
   return (
     <section>
-      <div className="md:grid md:grid-cols-2 md:gap-x-16 lg:gap-x-8 mb-20 md:mb-28">
-        <div>
-          <h3 className="mb-4 text-4xl lg:text-5xl leading-tight">
+      <div className="mb-10">
+        <div className="brutal-border bg-[color:var(--brutal-card)] p-5">
+          <h3 className="mb-3 text-3xl lg:text-4xl leading-tight">
             {isVideo && (
               <span className="mr-3 align-middle inline-block text-xs font-semibold uppercase tracking-wide text-red-600">Video</span>
             )}
             <PostLink externalUrl={externalUrl} title={title} slug={slug} />
           </h3>
           {Array.isArray(tags) && tags.length > 0 && (
-            <div className="mb-2 text-sm text-gray-600">
+            <div className="mb-2 text-sm text-gray-800">
               {tags.map((t) => (
                 <Link key={t} href={`/tags/${t}`}>
-                  <a className="mr-2 inline-block hover:underline">#{t}</a>
+                  <a className="brutal-tag">#{t}</a>
                 </Link>
               ))}
             </div>
           )}
-          <div className="mb-4 md:mb-0">
+          <div className="mb-1">
             <DateFormatter dateString={date} />
           </div>
         </div>

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -13,7 +13,7 @@ const Layout = ({ preview, children }: Props) => {
       <Meta />
       <div className="min-h-screen">
         {preview && <Alert />}
-        <main>{children}</main>
+        <main className="px-4 md:px-8 lg:px-12 max-w-5xl mx-auto">{children}</main>
       </div>
       <Footer />
     </>

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -13,7 +13,7 @@ type Props = {
 
 const PostPreview = ({ title, date, slug, externalUrl, isVideo, tags }: Props) => {
   return (
-    <div className="brutal-border bg-[color:var(--brutal-card)] p-4">
+    <div className="brutal-border bg-[color:var(--brutal-card)] p-4 text-[color:var(--brutal-fg)]">
       <h3 className="text-2xl mb-3 leading-snug">
         {isVideo && (
           <span className="mr-2 align-middle inline-block text-[10px] font-semibold uppercase tracking-wide text-red-600">Video</span>
@@ -21,7 +21,7 @@ const PostPreview = ({ title, date, slug, externalUrl, isVideo, tags }: Props) =
         <PostLink externalUrl={externalUrl} title={title} slug={slug} />
       </h3>
       {Array.isArray(tags) && tags.length > 0 && (
-        <div className="mb-2 text-sm text-gray-800">
+        <div className="mb-2 text-sm">
           {tags.map((t) => (
             <Link key={t} href={`/tags/${t}`}>
               <a className="brutal-tag">#{t}</a>

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -13,23 +13,23 @@ type Props = {
 
 const PostPreview = ({ title, date, slug, externalUrl, isVideo, tags }: Props) => {
   return (
-    <div>
-      <h3 className="text-3xl mb-3 leading-snug">
+    <div className="brutal-border bg-[color:var(--brutal-card)] p-4">
+      <h3 className="text-2xl mb-3 leading-snug">
         {isVideo && (
           <span className="mr-2 align-middle inline-block text-[10px] font-semibold uppercase tracking-wide text-red-600">Video</span>
         )}
         <PostLink externalUrl={externalUrl} title={title} slug={slug} />
       </h3>
       {Array.isArray(tags) && tags.length > 0 && (
-        <div className="mb-2 text-sm text-gray-600">
+        <div className="mb-2 text-sm text-gray-800">
           {tags.map((t) => (
             <Link key={t} href={`/tags/${t}`}>
-              <a className="mr-2 inline-block hover:underline">#{t}</a>
+              <a className="brutal-tag">#{t}</a>
             </Link>
           ))}
         </div>
       )}
-      <div className="mb-4">
+      <div className="mb-1">
         <DateFormatter dateString={date} />
       </div>
     </div>

--- a/components/tag-cloud.tsx
+++ b/components/tag-cloud.tsx
@@ -20,9 +20,9 @@ const TagCloud = ({ counts }: Props) => {
   const sorted = entries.sort(([a], [b]) => a.localeCompare(b));
 
   return (
-    <div className="mb-10">
-      <h2 className="text-xl mb-3">Tags</h2>
-      <div className="flex flex-wrap gap-x-3 gap-y-2 text-gray-700">
+    <div className="mb-10 brutal-border bg-[color:var(--brutal-card)] p-4">
+      <h2 className="text-xl mb-3 font-extrabold">Tags</h2>
+      <div className="flex flex-wrap gap-x-3 gap-y-2 text-gray-800">
         {sorted.map(([tag, n]) => (
           <Link key={tag} href={`/tags/${tag}`}>
             <a className={`hover:underline ${weightFor(n)}`}>#{tag}</a>
@@ -34,4 +34,3 @@ const TagCloud = ({ counts }: Props) => {
 };
 
 export default TagCloud;
-

--- a/components/tag-cloud.tsx
+++ b/components/tag-cloud.tsx
@@ -20,9 +20,9 @@ const TagCloud = ({ counts }: Props) => {
   const sorted = entries.sort(([a], [b]) => a.localeCompare(b));
 
   return (
-    <div className="mb-10 brutal-border bg-[color:var(--brutal-card)] p-4">
+    <div className="mb-10 brutal-border bg-[color:var(--brutal-card)] p-4 text-[color:var(--brutal-fg)]">
       <h2 className="text-xl mb-3 font-extrabold">Tags</h2>
-      <div className="flex flex-wrap gap-x-3 gap-y-2 text-gray-800">
+      <div className="flex flex-wrap gap-x-3 gap-y-2">
         {sorted.map(([tag, n]) => (
           <Link key={tag} href={`/tags/${tag}`}>
             <a className={`hover:underline ${weightFor(n)}`}>#{tag}</a>

--- a/components/theme-picker.tsx
+++ b/components/theme-picker.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+
+const THEMES = [
+  { id: "theme-brutal-1", label: "one" },
+  { id: "theme-brutal-2", label: "two" },
+  { id: "theme-brutal-3", label: "three" },
+  { id: "theme-brutal-dark", label: "dark" },
+] as const;
+
+const THEME_CLASSES = THEMES.map((t) => t.id);
+const STORAGE_KEY = "theme";
+
+function applyTheme(themeId: string) {
+  if (typeof document === "undefined") return;
+  const body = document.body;
+  THEME_CLASSES.forEach((c) => body.classList.remove(c));
+  if (themeId) body.classList.add(themeId);
+}
+
+export default function ThemePicker() {
+  const [theme, setTheme] = useState<string>(THEMES[1].id); // default to "two"
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      const initial = saved && THEME_CLASSES.includes(saved) ? saved : THEMES[1].id;
+      setTheme(initial);
+      applyTheme(initial);
+      if (!saved) localStorage.setItem(STORAGE_KEY, initial);
+    } catch {
+      // fallback already set via state
+      applyTheme(THEMES[1].id);
+    }
+  }, []);
+
+  function chooseTheme(id: string) {
+    setTheme(id);
+    applyTheme(id);
+    try {
+      localStorage.setItem(STORAGE_KEY, id);
+    } catch {}
+  }
+
+  return (
+    <div className="text-sm text-gray-700">
+      <span className="mr-2 font-semibold">theme:</span>
+      {THEMES.map((t, idx) => (
+        <span key={t.id}>
+          <a
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
+              chooseTheme(t.id);
+            }}
+            className={theme === t.id ? "font-extrabold" : "hover:underline"}
+          >
+            {t.label}
+          </a>
+          {idx < THEMES.length - 1 ? <span className="mx-2">|</span> : null}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/components/theme-picker.tsx
+++ b/components/theme-picker.tsx
@@ -7,7 +7,8 @@ const THEMES = [
   { id: "theme-brutal-dark", label: "dark" },
 ] as const;
 
-const THEME_CLASSES = THEMES.map((t) => t.id);
+type ThemeId = typeof THEMES[number]["id"];
+const THEME_CLASSES: ThemeId[] = THEMES.map((t) => t.id);
 const STORAGE_KEY = "theme";
 
 function applyTheme(themeId: string) {
@@ -17,13 +18,17 @@ function applyTheme(themeId: string) {
   if (themeId) body.classList.add(themeId);
 }
 
+function isThemeId(value: string | null): value is ThemeId {
+  return !!value && (THEME_CLASSES as readonly string[]).includes(value);
+}
+
 export default function ThemePicker() {
-  const [theme, setTheme] = useState<string>(THEMES[1].id); // default to "two"
+  const [theme, setTheme] = useState<ThemeId>(THEMES[1].id); // default to "two"
 
   useEffect(() => {
     try {
       const saved = localStorage.getItem(STORAGE_KEY);
-      const initial = saved && THEME_CLASSES.includes(saved) ? saved : THEMES[1].id;
+      const initial: ThemeId = isThemeId(saved) ? saved : THEMES[1].id;
       setTheme(initial);
       applyTheme(initial);
       if (!saved) localStorage.setItem(STORAGE_KEY, initial);
@@ -33,7 +38,7 @@ export default function ThemePicker() {
     }
   }, []);
 
-  function chooseTheme(id: string) {
+  function chooseTheme(id: ThemeId) {
     setTheme(id);
     applyTheme(id);
     try {
@@ -42,7 +47,7 @@ export default function ThemePicker() {
   }
 
   return (
-    <div className="text-sm text-gray-700">
+    <div className="text-sm text-[color:var(--brutal-fg)]">
       <span className="mr-2 font-semibold">theme:</span>
       {THEMES.map((t, idx) => (
         <span key={t.id}>

--- a/styles/index.css
+++ b/styles/index.css
@@ -2,13 +2,42 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Brutalist theme tokens (first pass) */
-:root {
-  --brutal-bg: #fffbe6; /* warm off-white */
-  --brutal-fg: #111827; /* slate-900 */
-  --brutal-accent: #ff3b3b; /* punchy red */
-  --brutal-accent-2: #00a3ff; /* cyan blue */
+/* Brutalist theme tokens (palettes) */
+/* Default (Theme 1): warm off-white + red/cyan accents */
+:root,
+.theme-brutal-1 {
+  --brutal-bg: #fffbe6;
+  --brutal-fg: #111827;
+  --brutal-accent: #ff3b3b;
+  --brutal-accent-2: #00a3ff;
   --brutal-card: #ffffff;
+}
+
+/* Theme 2: lime wash + sky/red accents */
+.theme-brutal-2 {
+  --brutal-bg: #ecfccb; /* lime-100 */
+  --brutal-fg: #0f172a; /* slate-900 */
+  --brutal-accent: #0ea5e9; /* sky-500 */
+  --brutal-accent-2: #ef4444; /* red-500 */
+  --brutal-card: #ffffff;
+}
+
+/* Theme 3: slate wash + green/amber accents */
+.theme-brutal-3 {
+  --brutal-bg: #f1f5f9; /* slate-100 */
+  --brutal-fg: #020617; /* slate-950 */
+  --brutal-accent: #22c55e; /* green-500 */
+  --brutal-accent-2: #f59e0b; /* amber-500 */
+  --brutal-card: #ffffff;
+}
+
+/* Theme 4 (dark): near-black + yellow/cyan accents */
+.theme-brutal-dark {
+  --brutal-bg: #0a0a0a;
+  --brutal-fg: #f5f5f5;
+  --brutal-accent: #ffcc00;
+  --brutal-accent-2: #00e5ff;
+  --brutal-card: #111111;
 }
 
 /* Utilities */

--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,10 @@
   --brutal-accent: #ff3b3b;
   --brutal-accent-2: #00a3ff;
   --brutal-card: #ffffff;
+  --brutal-border: #000000;
+  --brutal-shadow: #000000;
+  --brutal-tag-bg: #fde68a; /* amber-300 */
+  --brutal-tag-fg: #111827;
 }
 
 /* Theme 2: lime wash + sky/red accents */
@@ -20,6 +24,10 @@
   --brutal-accent: #0ea5e9; /* sky-500 */
   --brutal-accent-2: #ef4444; /* red-500 */
   --brutal-card: #ffffff;
+  --brutal-border: #000000;
+  --brutal-shadow: #000000;
+  --brutal-tag-bg: #fef08a; /* yellow-300 */
+  --brutal-tag-fg: #0f172a;
 }
 
 /* Theme 3: slate wash + green/amber accents */
@@ -29,6 +37,10 @@
   --brutal-accent: #22c55e; /* green-500 */
   --brutal-accent-2: #f59e0b; /* amber-500 */
   --brutal-card: #ffffff;
+  --brutal-border: #000000;
+  --brutal-shadow: #000000;
+  --brutal-tag-bg: #d1fae5; /* emerald-100 */
+  --brutal-tag-fg: #022c22;
 }
 
 /* Theme 4 (dark): near-black + yellow/cyan accents */
@@ -37,22 +49,22 @@
   --brutal-fg: #f5f5f5;
   --brutal-accent: #ffcc00;
   --brutal-accent-2: #00e5ff;
-  --brutal-card: #111111;
+  --brutal-card: #161616; /* lighter than bg for contrast */
+  --brutal-border: #ffffff; /* visible borders */
+  --brutal-shadow: #ffffff;
+  --brutal-tag-bg: #222222;
+  --brutal-tag-fg: #f5f5f5;
 }
 
 /* Utilities */
-.brutal-border {
-  @apply border-4 border-black shadow-[6px_6px_0_0_#000];
-}
+.brutal-border { border: 4px solid var(--brutal-border); box-shadow: 6px 6px 0 0 var(--brutal-shadow); }
 .brutal-button {
   @apply brutal-border bg-[color:var(--brutal-accent)] text-white px-4 py-2 font-bold uppercase tracking-wide;
 }
 .brutal-link {
   @apply underline decoration-4 decoration-[color:var(--brutal-accent)] hover:decoration-[color:var(--brutal-accent-2)];
 }
-.brutal-tag {
-  @apply brutal-border bg-yellow-200 px-2 py-0.5 text-xs mr-2 mb-2 inline-block;
-}
+.brutal-tag { display:inline-block; margin-right:0.5rem; margin-bottom:0.5rem; padding:0.125rem 0.5rem; font-size:0.75rem; background: var(--brutal-tag-bg); color: var(--brutal-tag-fg); }
 
 /* Page background */
 body {

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,3 +1,32 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Brutalist theme tokens (first pass) */
+:root {
+  --brutal-bg: #fffbe6; /* warm off-white */
+  --brutal-fg: #111827; /* slate-900 */
+  --brutal-accent: #ff3b3b; /* punchy red */
+  --brutal-accent-2: #00a3ff; /* cyan blue */
+  --brutal-card: #ffffff;
+}
+
+/* Utilities */
+.brutal-border {
+  @apply border-4 border-black shadow-[6px_6px_0_0_#000];
+}
+.brutal-button {
+  @apply brutal-border bg-[color:var(--brutal-accent)] text-white px-4 py-2 font-bold uppercase tracking-wide;
+}
+.brutal-link {
+  @apply underline decoration-4 decoration-[color:var(--brutal-accent)] hover:decoration-[color:var(--brutal-accent-2)];
+}
+.brutal-tag {
+  @apply brutal-border bg-yellow-200 px-2 py-0.5 text-xs mr-2 mb-2 inline-block;
+}
+
+/* Page background */
+body {
+  background: var(--brutal-bg);
+  color: var(--brutal-fg);
+}


### PR DESCRIPTION
## Summary
First pass at a brutalist redesign inspired by https://brutal.elian.codes. Focus is on high-contrast, chunky borders, and bold typography while keeping the existing structure and content flows.

## Visual Changes
- Added brutalist tokens and utilities (thick borders, badges, punchy accents)
- Chunky site title block and padded layout container
- Card treatment for hero and post previews with visible outlines/shadows
- Tag badges and improved tag cloud presentation

## Implementation
- styles/index.css: theme variables and utilities (`.brutal-border`, `.brutal-tag`, etc.)
- components/layout.tsx: centered, padded main container
- components/header.tsx: bold bordered site title block
- components/hero-post.tsx: card layout, tag badges, tightened spacing
- components/post-preview.tsx: card layout, tag badges under title
- components/tag-cloud.tsx: bordered container, stronger heading

## QA
- Typecheck and `next build` pass locally
- Static export remains compatible (no runtime dependency changes)
- No breaking changes to routes or content loading

## Screenshots
If you'd like, I can add screenshots/GIFs. A few I plan to include:
- Homepage header + hero card
- Post list item (with Video badge)
- Tag cloud block
- Tag page header + filtered list

## Next Steps (optional)
- Tune colors/accents; add hover/active states
- Apply the treatment to Footer and any remaining components
- Consider a “theme toggle” flag to switch brutalist mode on/off
- Explore denser grid for post list (2–3 columns at large breakpoints)

---

Tracking branch: `redesign/brutal` → base `main`.
